### PR TITLE
bump to crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,8 @@
 name: inflector
 version: 0.1.8
 
+crystal: 1.0.0
+
 authors:
   - Paul Hoffer <paulrhoffer@gmail.com>
 


### PR DESCRIPTION
This PR just flag the lib as crystal: 1.0.0 or it will fail when using `shard install`  with the 1.0.0 release.