### PR TITLE
Update shard version to match the latest tag

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: inflector
-version: 0.1.8
+version: 1.0.0
 
 crystal: 1.0.0
 


### PR DESCRIPTION
The version in `shard.yml` doesn't match the latest tag.

This will get rid of the warning when installing the shard:

    Shard "inflector" version (0.1.8) doesn't match tag version (1.0.0)